### PR TITLE
Concourse pipeline to track ingress-nginx controller releases

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,78 @@
+---
+
+resources:
+
+  - name: ingress-nginx-tracing-repository
+    type: git
+    icon: github
+    source: &ingress-nginx-tracing-repo-config
+      uri: https://github.com/instana/ingress-nginx-tracing.git
+      username: ((project-berlin-gh-token))
+      password: x-oauth-basic
+      branch: &ingress-nginx-build-branch pipeline # Change to 'main' when merging the pipeline branch
+
+  - name: pipeline-source
+    type: git
+    icon: github
+    source:
+      <<: *ingress-nginx-tracing-repo-config
+      paths:
+      - ci/
+
+  - name: ingress-nginx-repository
+    type: git
+    icon: github
+    source: &ingress-nginx-tracing-repo-config
+      uri: https://github.com/kubernetes/ingress-nginx.git
+      username: ((project-berlin-gh-token))
+      password: x-oauth-basic
+
+  - name: ingress-nginx-releases
+    type: github-release
+    icon: github
+    source:
+      owner: kubernetes
+      repository: ingress-nginx
+      access_token: ((project-berlin-gh-token))
+      release: true
+      pre_release: false
+      tag_filter: controller-v(.*)
+
+jobs:
+
+  - name: self-update
+    plan:
+      - get: pipeline-source
+        trigger: true
+      - set_pipeline: self
+        file: pipeline-source/ci/pipeline.yml
+        vars:
+          branch: *ingress-nginx-build-branch
+          project-berlin-gh-token: ((project-berlin-gh-token))
+
+  - name: create-pr-for-new-controller-release
+    plan:
+      - in_parallel:
+        - get: ingress-nginx-releases
+          trigger: true
+        - get: ingress-nginx-repository
+        - get: ingress-nginx-tracing-repository
+      - task: create-new-branch
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: openjdk
+              tag: slim-buster
+          inputs:
+            - name: ingress-nginx-repository
+            - name: ingress-nginx-tracing-repository
+            - name: ingress-nginx-releases
+          params:
+            GITHUB_TOKEN: ((project-berlin-gh-token))
+          run:
+            path: /bin/bash
+            args:
+              - -exc
+              - ingress-nginx-tracing-repository/ci/scripts/prepare-build-branch

--- a/ci/scripts/extract_controller_image.rb
+++ b/ci/scripts/extract_controller_image.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+deployment_document = YAML.load_stream(ARGF.read).find { |document| document['kind'] == 'Deployment' && document['metadata']['labels'] && document['metadata']['labels']['app.kubernetes.io/component'] == 'controller' } 
+controller_container_spec = deployment_document['spec']['template']['spec']['containers'].find { |container| container['name'] == 'controller' }
+
+puts controller_container_spec['image']

--- a/ci/scripts/prepare-build-branch
+++ b/ci/scripts/prepare-build-branch
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+echo -n 'Installing dependencies ... '
+
+apt update > /dev/null 2>&1 && apt install -y git curl ruby > /dev/null 2>&1
+chmod u+x ./ingress-nginx-tracing-repository/ci/scripts/extract_controller_image.rb
+
+echo 'OK'
+
+readonly RELEASE_TAG=$(cat ingress-nginx-releases/tag)
+readonly RELEASE_COMMIT_SHA=$(cat ingress-nginx-releases/commit_sha)
+
+echo -n "Retrieving container image for release ${RELEASE_TAG} (commit sha: ${RELEASE_COMMIT_SHA}) ... "
+
+(cd ingress-nginx-repository && git checkout ${RELEASE_COMMIT_SHA} > /dev/null 2>&1)
+
+readonly DEPLOYMENT_FILE='ingress-nginx-repository/deploy/static/provider/cloud/deploy.yaml'
+readonly CONTROLLER_IMAGE=$(./ingress-nginx-tracing-repository/ci/scripts/extract_controller_image.rb < "${DEPLOYMENT_FILE}")
+
+echo "${CONTROLLER_IMAGE}"
+
+echo "Preparing the ${RELEASE_TAG} branch ..."
+
+pushd ingress-nginx-tracing-repository
+git checkout -b ${RELEASE_TAG}
+
+# TODO Calculate these dynamically
+libc_flavor='musl'
+nginx_version='nginx/1.19.1'
+
+echo "
+[ingress-nginx-controller-${RELEASE_TAG}]
+repo=https://github.com/kubernetes/ingress-nginx
+tag=ingress-nginx-${RELEASE_TAG}
+docker_image=${CONTROLLER_IMAGE}" >> build/init-container-config
+
+git config --global 'user.email' 'stan@instana.com'
+git config --global 'user.name' 'Stan'
+
+git add build/init-container-config
+git commit -m "Add build specification for ${RELEASE_TAG}"
+
+readonly REMOTE_URL="$(git remote get-url origin)"
+
+readonly REMOTE_WITH_AUTH="$(echo ${REMOTE_URL} | sed "s'://'&${GITHUB_TOKEN}@'g" )"
+
+git push -f "${REMOTE_WITH_AUTH}" HEAD:refs/heads/${RELEASE_TAG}
+
+popd
+
+# TODO Create PR


### PR DESCRIPTION
Create a [Concourse pipeline](https://ci.instana.io/teams/proxies/pipelines/ingress-nginx-tracing) that automatically creates branches in this repository for new versions of `ingress-nginx controller` images to be supported.